### PR TITLE
free disk space improvements

### DIFF
--- a/disk-filltest.c
+++ b/disk-filltest.c
@@ -282,8 +282,13 @@ void write_randfiles(void)
         struct statvfs buf;
 
         if (statvfs(".", &buf) == 0) {
-            uint64_t free_size =
-                (uint64_t)(buf.f_blocks) * (uint64_t)(buf.f_frsize);
+            uint64_t free_blocks;
+            if (geteuid() == 0)
+                free_blocks = (uint64_t)(buf.f_bfree);
+            else
+                free_blocks = (uint64_t)(buf.f_bavail);
+
+            uint64_t free_size = free_blocks * (uint64_t)(buf.f_frsize);
 
             expected_file_limit = (free_size + gopt_file_size - 1)
                 / (1024 * 1024) / gopt_file_size;

--- a/disk-filltest.c
+++ b/disk-filltest.c
@@ -283,7 +283,7 @@ void write_randfiles(void)
 
         if (statvfs(".", &buf) == 0) {
             uint64_t free_size =
-                (uint64_t)(buf.f_blocks) * (uint64_t)(buf.f_bsize);
+                (uint64_t)(buf.f_blocks) * (uint64_t)(buf.f_frsize);
 
             expected_file_limit = (free_size + gopt_file_size - 1)
                 / (1024 * 1024) / gopt_file_size;


### PR DESCRIPTION
a few improvements to free disk space calculation:

1. On Windows, use `GetDiskFreeSpaceEx`.
2. Use `f_frsize` instead of `f_bsize`, to get the correct block size on macOS (doesn't affect Windows or Linux).
3. Use `f_bfree` & `f_bavail` to compute free blocks. Previous `f_blocks` was computing total blocks, rather than free blocks. Choose bfree or bavail based on whether we're privileged or not. This matters on Linux, where part of the filesystem is often reserved for root.

Tested on Windows (`x86_64-w64-mingw32-gcc`), Cygwin (uses `statvfs` api), macOS, Linux, but _not_ on MSVC.